### PR TITLE
Release/3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.1] - 2022-02-17
+
+### Added
+
+- Include additional changes for CASMCMS-7676 (IMS templating) missed during repo conversion
+
 ## [3.0.0] - 2022-02-14
 
 ### Changed
@@ -30,8 +36,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - See https://github.com/Cray-HPE/cray-product-install-charts for this release and prior.
 
 
-[Unreleased]: https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/compare/v3.0.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/compare/v3.0.1...HEAD
 
+[3.0.1]: https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/compare/v3.0.0...v3.0.1
 
 [3.0.0]: https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/compare/v2.0.0...v3.0.0
 

--- a/charts/cray-import-kiwi-recipe-image/templates/configmap.yaml
+++ b/charts/cray-import-kiwi-recipe-image/templates/configmap.yaml
@@ -31,7 +31,7 @@ metadata:
   labels:
     app.kubernetes.io/name: cray-ims
 data:
-  template_dictionary:
+  template_dictionary: |
     {{- with .Values.import_job.IMS_TEMPLATE_DICTIONARY -}}
     {{ toYaml . | nindent 4 -}}
     {{- end }}

--- a/charts/cray-import-kiwi-recipe-image/templates/job.yaml
+++ b/charts/cray-import-kiwi-recipe-image/templates/job.yaml
@@ -87,7 +87,7 @@ spec:
           name: catalog-overlay
       {{- if gt (len .Values.import_job.IMS_TEMPLATE_DICTIONARY) 0 }}
         - name: template-dictionary
-          mountPath: /
+          mountPath: /mnt/image-recipe-import/
       {{- end }}
         env:
         - name: DOWNLOAD_PATH


### PR DESCRIPTION
## Summary and Scope

A few changes were added to CASMCMS-7676 after full testing that were not available when this repository was created from the old cray-product-install-charts repository. Release a patch (3.0.1) to include those final changes.

## Issues and Related PRs

* CASMCMS-7676

## Testing

See https://github.com/Cray-HPE/cray-product-install-charts/pull/5

## Risks and Mitigations

See https://github.com/Cray-HPE/cray-product-install-charts/pull/5

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable

