### PR TITLE
Use github public ubuntu runner instead of self-hosted on public repos.

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -93,7 +93,7 @@ on:
 jobs:
 
   build-prep:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       semVer: ${{ steps.buildprepversion.outputs.version }}
       chart-version: ${{ steps.buildversion.outputs.chart-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [3.0.2] - 2022-03-04
+
+### Changed
+
+- Use github public ubuntu runner instead of self-hosted on public repos.
+
 ## [3.0.1] - 2022-02-17
 
 ### Added
@@ -36,7 +42,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - See https://github.com/Cray-HPE/cray-product-install-charts for this release and prior.
 
 
-[Unreleased]: https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/compare/v3.0.2...HEAD
+
+[3.0.2]: https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/compare/v3.0.1...v3.0.2
 
 [3.0.1]: https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/compare/v3.0.0...v3.0.1
 


### PR DESCRIPTION
## Summary and Scope

Use github public ubuntu runner instead of self-hosted on public repos.

## Issues and Related PRs

* Resolves CASMCMS-7878

## Testing

Chart built successfully with proper version.

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
