### PR TITLE
CASMCMS-7922: Use BOS V2's session template endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Update license text to comply with automatic license-check tool.
 
+- Utilize BOS Version 2 (BOS V2) endpoint for session templates. Further, change the variable name from BOS_SESSION_ENDPOINT to BOS_SESSIONTEMPLATES_ENDPOINT.
+	
 ## [3.0.2] - 2022-03-04
 
 ### Changed

--- a/charts/cray-import-kiwi-recipe-image/Chart.yaml
+++ b/charts/cray-import-kiwi-recipe-image/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-import-kiwi-recipe-image
-version: 2.1.0
+version: 2.2.0
 description: Base chart for importing Cray-authored Kiwi Descriptions and images into
   IMS/S3 on Shasta systems.
 keywords:

--- a/charts/cray-import-kiwi-recipe-image/values.yaml
+++ b/charts/cray-import-kiwi-recipe-image/values.yaml
@@ -71,7 +71,7 @@ import_job:
 
   CREATE_BOS_SESSION_TEMPLATE: "False"
   BOS_URL: "http://cray-bos"
-  BOS_SESSION_ENDPOINT: "v1/sessiontemplate"
+  BOS_SESSIONTEMPLATES_ENDPOINT: "v2/sessiontemplates"
   BOS_KERNEL_PARAMETERS: >-
     console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable
     iommu=pt ip=dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14


### PR DESCRIPTION
## Summary and Scope

Update the BOS session template endpoint to point at BOS V2's endpoint

This change is backwards incompatible only in the sense that we're moving forward with BOS V2.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMCMS-7922.
* Change will also be needed in `master`, so that this is published correctly.

## Testing

None.

### Tested on:


### Test description:
Didn't.
 ## Risks and Mitigations
This is low risk.


## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [ ] Is a new version being released? Update https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/wiki/CSM-Compatibility-Matrix
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

