### PR TITLE
CASMCMS-7922: Use BOS V2's session template endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [3.1.0] - 2022-08-02
 
 ### Changed
+
 - Update license text to comply with automatic license-check tool.
 - CASMCMS-7970 - update dev.cray.com addresses.
 
-	
 ## [3.0.2] - 2022-03-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Utilize BOS Version 2 (BOS V2) endpoint for session templates. Further, change the variable name from `BOS_SESSION_ENDPOINT` to `BOS_SESSIONTEMPLATES_ENDPOINT`.
+
 ## [3.2.0] - 2023-04-06
 
 ### Changed
@@ -21,10 +25,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [3.1.0] - 2022-08-02
 
 ### Changed
-
 - Update license text to comply with automatic license-check tool.
 - CASMCMS-7970 - update dev.cray.com addresses.
 
+	
 ## [3.0.2] - 2022-03-04
 
 ### Changed

--- a/charts/cray-import-kiwi-recipe-image/Chart.yaml
+++ b/charts/cray-import-kiwi-recipe-image/Chart.yaml
@@ -39,6 +39,9 @@ maintainers:
 - name: dlaine-hpe
   email: laine@hpe.com
   url: https://github.com/orgs/Cray-HPE/teams/cray-management-systems
+- name: jsollom-hpe
+  email: jason.sollom@hpe.com
+  url: https://github.com/orgs/Cray-HPE/teams/cray-management-systems
 sources:
 - https://github.com/Cray-HPE/cray-product-install-charts
 annotations:

--- a/charts/cray-import-kiwi-recipe-image/values.yaml
+++ b/charts/cray-import-kiwi-recipe-image/values.yaml
@@ -72,7 +72,7 @@ import_job:
 
   CREATE_BOS_SESSION_TEMPLATE: "False"
   BOS_URL: "http://cray-bos"
-  BOS_SESSION_ENDPOINT: "v1/sessiontemplate"
+  BOS_SESSIONTEMPLATES_ENDPOINT: "v2/sessiontemplates"
   BOS_KERNEL_PARAMETERS: >-
     console=ttyS0,115200 bad_page=panic crashkernel=340M hugepagelist=2m-2g intel_iommu=off intel_pstate=disable
     iommu=pt ip=dhcp numa_interleave_omit=headless numa_zonelist_order=node oops=panic pageblock_order=14


### PR DESCRIPTION
## Summary and Scope

Update the BOS session template endpoint to point at BOS V2's endpoint
Change the environment variable name from BOS_SESSION_ENDPOINT to
BOS_SESSIONTEMPLATES_ENDPOINT.
## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMCMS-7922
* Documentation changes required in compatibility matrix

## Testing


### Tested on:

  * Locally

### Test description:

I built a chart using the previously published version of this Chart. I wasn't sure how to publish this chart without actually releasing it.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? No
- Was upgrade tested? If not, why? No
- Was downgrade tested? If not, why? No
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
- [x] Is a new version being released? Update https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/wiki/CSM-Compatibility-Matrix
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

