### PR TITLE
CASMTRIAGE-5163: Update to Cray Product Catalog version 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Reverted github workflows back to Jenkins pipelines.
 - Finished conversion to GitVersion; modified build and versioning process to match other CMS repositories.
+- Update to cray-product-catalog-update version 1.8.x
 
 ### Removed
 

--- a/charts/cray-import-kiwi-recipe-image/Chart.yaml
+++ b/charts/cray-import-kiwi-recipe-image/Chart.yaml
@@ -33,7 +33,12 @@ keywords:
 - kiwi
 home: https://github.com/Cray-HPE/cray-product-install-charts
 maintainers:
-  - name: Cray-HPE/teams/cray-management-systems
+- name: mharding-hpe
+  email: mitchell.harding@hpe.com
+  url: https://github.com/orgs/Cray-HPE/teams/cray-management-systems
+- name: dlaine-hpe
+  email: laine@hpe.com
+  url: https://github.com/orgs/Cray-HPE/teams/cray-management-systems
 sources:
 - https://github.com/Cray-HPE/cray-product-install-charts
 annotations:

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,5 +80,5 @@
 
 image: cray-product-catalog-update
     major: 1
-    minor: 5
+    minor: 8
 


### PR DESCRIPTION
## Summary and Scope

Because we are using an older version of the Cray Product Catalog to import the CSM barebones image, on upgrades to CSM 1.4, data is lost in the product catalog. 

This PR will make a new version of the cray-import-kiwi-recipe-image base chart using the latest CPC version. This base chart will then be used for a new version of the barebones image installer. See [CASMTRIAGE-5163](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5163) for details.

## Testing

The new CPC version is already being used in other contexts to update the product catalog. It has been extensively tested.

## Risks and Mitigations

Low risk. Anyone using the current version of this base chart won't see a change. It will only impact those who move to use the new version, which in the short term will just be us.

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
