### PR TITLE
Casmcms 8743

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.1.0] - 2023-08-14
+- CASMCMS-8743 - fix BOS V2 session endpoint template generation.
+
 ## [4.0.0] - 2023-05-23
 
 ### Changed

--- a/charts/cray-import-kiwi-recipe-image/templates/job.yaml
+++ b/charts/cray-import-kiwi-recipe-image/templates/job.yaml
@@ -122,8 +122,8 @@ spec:
 
         - name: BOS_URL
           value: "{{ .Values.import_job.BOS_URL }}"
-        - name: BOS_SESSION_ENDPOINT
-          value: "{{ .Values.import_job.BOS_SESSION_ENDPOINT }}"
+        - name: BOS_SESSIONTEMPLATES_ENDPOINT
+          value: "{{ .Values.import_job.BOS_SESSIONTEMPLATES_ENDPOINT }}"
         - name: BOS_KERNEL_PARAMETERS
           value: "{{ .Values.import_job.BOS_KERNEL_PARAMETERS }}"
         - name: BOS_ROOTFS_PROVIDER


### PR DESCRIPTION
## Summary and Scope

The code in image-recipes that uses this helm chart is looking for the env var 'BOS_SESSIONTEMPLATES_ENDPOINT` or 'BOS_SESSION_ENDPOINT` to determine whether to use bos v1 or v2. The old one 'BOS_SESSION_ENDPOINT' was defined, but not set to anything. That was leading to an incorrect bos version assumption, and an invalid bos endpoint. The creation of the bos template was failing due to this for the image import.

## Issues and Related PRs
* Resolves [CASMCMS-8743](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8743)
* Change will also be needed in other repos

## Testing
### Tested on:
  * `Mug`

### Test description:

I build image-recipes using this unstable helm chart, built the install service, then did a helm upgrade on Mug. I confirmed the images were imported correctly and each image had a corresponding bos v2 session template created for it.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk as this was not working previously.

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

