### PR TITLE
CASMCMS-9132 - update cray-product-catalog version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [4.4.3] - 2024-09-16
+
+### Dependencies
+- Bump `cray-product-catalog` from 2.3 to 2.4 for CSM 1.6
+
 ## [4.4.2] - 2024-07-16
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [4.4.3] - 2024-09-16
 
 ### Dependencies
-- Bump `cray-product-catalog` from 2.3 to 2.4 for CSM 1.6
+- Bump `cray-product-catalog` from 2.3 to 2.5 for CSM 1.6
 
 ## [4.4.2] - 2024-07-16
 

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,4 +80,4 @@
 
 image: cray-product-catalog-update
     major: 2
-    minor: 3
+    minor: 4

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,4 +80,4 @@
 
 image: cray-product-catalog-update
     major: 2
-    minor: 4
+    minor: 5


### PR DESCRIPTION
## Summary and Scope

The cray-product-catalog image needed to be updated to keep up with the k8s version being released with csm-1.6.0. This picks up the new version of the image.

## Issues and Related PRs
* Resolves [CASMCMS-9132](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9132)

## Testing
### Tested on:
  * `Mug`

## Risks and Mitigations

Low risk - just picking up a new dependency version.

## Pull Request Checklist

- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] Is a new version being released? Update https://github.com/Cray-HPE/cray-import-kiwi-recipe-image/wiki/CSM-Compatibility-Matrix
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

